### PR TITLE
Include check of slurm job timeout, and treat it as a failed trial

### DIFF
--- a/MOBO-tools/ProjectUtils/checkSlurmStatus.sh
+++ b/MOBO-tools/ProjectUtils/checkSlurmStatus.sh
@@ -11,6 +11,6 @@ if [ "$state" == "COMPLETED" ] && [ "$exit_code" == "0:0" ]; then
     echo 1
 elif [ "$state" == "PENDING" ] || [ "$state" == "RUNNING" ] || [ "$state" == "COMPLETING" ] || [ "$state" == "SUSPENDED" ]; then
     echo 0
-elif [ "$state" == "FAILED" ]; then
+elif [ "$state" == "FAILED" ] || [ "$state" == "TIMEOUT" ] || [ "$state" == "OUT_OF_MEMORY" ]; then
     echo -1
 fi


### PR DESCRIPTION
checkSlurmStatus.sh was not checking for trial job timeouts, leaving the slurm scheduler hanging.