### PR TITLE
Fix build errors with new eic-shell

### DIFF
--- a/MOBO-tools/ProjectUtils/ePICUtils/Makefile
+++ b/MOBO-tools/ProjectUtils/ePICUtils/Makefile
@@ -2,7 +2,7 @@
 # Compiler
 CXX := g++
 # Compiler flags
-CXXFLAGS := -Wall -Wno-deprecated -I$(shell root-config --incdir) $(shell root-config --glibs) -L/usr/local/lib -lpodio -lpodioRootIO -ledm4hep -ledm4eic
+CXXFLAGS := -Wall -Wno-deprecated -I$(shell root-config --incdir) $(shell root-config --glibs) -L/opt/local/lib -lpodio -lpodioRootIO -ledm4hep -ledm4eic -I/opt/local/include
 
 dRICHAna: dRICHAna.cpp
 	$(CXX) -o dRICHAna dRICHAna.cpp $(CXXFLAGS)


### PR DESCRIPTION
Some libraries have been moved in recent version of `eic-shell`. This PR will aim to get this repo back to a working state.

Soon, we should implement some way to control the version of `eic-shell` used, as mentioned by @karthik18495